### PR TITLE
Whitelist Gemfile as a trigger for rvm load

### DIFF
--- a/rvm.load
+++ b/rvm.load
@@ -12,7 +12,7 @@ function __check_rvm --on-variable PWD --description 'Setup rvm on directory cha
         end
         break
       else
-        if begin ; test -s ".rvmrc" ; or test -s ".ruby-version" ; or test -s ".ruby-gemset" ; or test -s ".versions.conf" ; end
+        if begin ; test -s ".rvmrc" ; or test -s ".ruby-version" ; or test -s ".ruby-gemset" ; or test -s ".versions.conf" ;  or test -s "Gemfile"; end
           rvm reload 1> /dev/null 2>&1
           rvm rvmrc load 1>/dev/null 2>&1
           break


### PR DESCRIPTION
With rvm users can specify their ruby version and gemset in the Gemfile. This PR adds Gemfile to the list of triggers for rvm.