### PR TITLE
Changed eval to source for fish v2.5.0 compatibility

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -9,11 +9,10 @@ function rvm -d 'Ruby enVironment Manager'
   # grep the rvm_* *PATH RUBY_* GEM_* variables from the captured environment
   # exclude lines with _clr and _debug
   # apply rvm_* *PATH RUBY_* GEM_* variables from the captured environment
-  and eval ( \
-    grep '^rvm\|^[^=]*PATH\|^RUBY_\|^GEM_' $env_file | \
-    grep -v _clr | grep -v _debug | \
-    sed '/^PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//' \
-  )
+  and grep '^rvm\|^[^=]*PATH\|^RUBY_\|^GEM_' $env_file | \
+      grep -v _clr | grep -v _debug | \
+      sed '/^PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//' | \
+      source 
 
   # clean up
   rm -f $env_file


### PR DESCRIPTION
I'm submitting following pull request to fix an issue related to `eval` / `source` usage within fish scripts. This change is for fish v2.5.0 compatibility

More details about mentioned issue in following discussions:
* syl20bnr/spacemacs/issues/4755 (the issue i've initially ran into) 
* purcell/exec-path-from-shell/issues/56
* fish-shell/fish-shell/issues/3809 (the solution implemented was proposed in this thread)

Similar PR was submited to RVM: 