### PR TITLE
Fix path names when used in WSL

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -11,7 +11,7 @@ function rvm -d 'Ruby enVironment Manager'
   # apply rvm_* *PATH RUBY_* GEM_* variables from the captured environment
   and grep '^rvm\|^[^=]*PATH\|^RUBY_\|^GEM_' $env_file | \
       grep -v _clr | grep -v _debug | \
-      sed '/^PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//' | \
+      sed '/^PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/; s/(//; s/)//' | \
       source 
 
   # clean up

--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -11,7 +11,7 @@ function rvm -d 'Ruby enVironment Manager'
   # apply rvm_* *PATH RUBY_* GEM_* variables from the captured environment
   and grep '^rvm\|^[^=]*PATH\|^RUBY_\|^GEM_' $env_file | \
       grep -v _clr | grep -v _debug | \
-      sed '/^PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/; s/(//; s/)//' | \
+      sed '/^PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/' | \
       source 
 
   # clean up


### PR DESCRIPTION
This fixes some long-standing bugs with the environment parser by simply putting quotes around each path and removing broken behavior regarding subshell invocation.